### PR TITLE
KAN-12: OpenAI API Call

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.4.6",
+        "openai": "^5.19.1",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -4844,6 +4845,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.19.1.tgz",
+      "integrity": "sha512-zSqnUF7oR9ksmpusKkpUgkNrj8Sl57U+OyzO8jzc7LUjTMg4DRfR3uCm+EIMA6iw06sRPNp4t7ojp3sCpEUZRQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.4.6",
+    "openai": "^5.19.1",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.6"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/frontend/src/app/api/generate/route.ts
+++ b/frontend/src/app/api/generate/route.ts
@@ -1,0 +1,37 @@
+import OpenAI from 'openai';
+import { NextRequest, NextResponse } from 'next/server';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const { prompt } = await request.json();
+
+    if (!prompt) {
+      return NextResponse.json({ error: 'Prompt is required' }, { status: 400 });
+    }
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-3.5-turbo",
+      messages: [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      max_tokens: 500,
+    });
+
+    const generatedText = completion.choices[0]?.message?.content || '';
+
+    return NextResponse.json({ generatedText });
+  } catch (error) {
+    console.error('OpenAI API error:', error);
+    return NextResponse.json(
+      { error: 'Failed to generate content' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/generate/page.tsx
+++ b/frontend/src/app/generate/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function GeneratePage() {
+  const [prompt, setPrompt] = useState('');
+  const [generatedText, setGeneratedText] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!prompt.trim()) return;
+
+    setIsLoading(true);
+    try {
+      const response = await fetch('/api/generate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ prompt }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setGeneratedText(data.generatedText);
+      } else {
+        console.error('Error:', data.error);
+        setGeneratedText('Error generating content. Please try again.');
+      }
+    } catch (error) {
+      console.error('Request failed:', error);
+      setGeneratedText('Error generating content. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen p-8">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold mb-8">Generate Content</h1>
+        
+        <form onSubmit={handleSubmit} className="mb-8">
+          <div className="mb-4">
+            <label htmlFor="prompt" className="block text-sm font-medium mb-2">
+              Enter a prompt:
+            </label>
+            <input
+              type="text"
+              id="prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter a prompt to generate content..."
+              disabled={isLoading}
+            />
+          </div>
+          
+          <button
+            type="submit"
+            disabled={isLoading || !prompt.trim()}
+            className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isLoading ? 'Generating...' : 'Generate'}
+          </button>
+        </form>
+
+        {generatedText && (
+          <div className="bg-gray-50 p-6 rounded-lg">
+            <h2 className="text-lg text-black font-semibold mb-3">Generated Content:</h2>
+            <p className="text-gray-700 whitespace-pre-wrap">{generatedText}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Purpose

<!-- A brief description of the PR -->

A setup of an OpenAI API running in /generate, with a simple input field on a route for first iteration.
**Note:** OpenAI API is currently in frontend for testing only. Will move to backend in next iteration.

## Steps to check/test this change

1. Add OpenAI API key to your .env.local file
2. Run localhost:3000/generate
3. test out the input field

<!--Insert steps required for reviewers to check/test this change -->

## Checklist

- [x] Tested in development
- [ ] Test coverage added

## Proof

This may be a before and after, a screenshot of a console output, or some other visual proof that your changes worked as desired. This proof is **mandatory**

<!-- Optional: if affecting UI -->

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <Before screenshot or video> | 
<img width="1504" height="888" alt="image" src="https://github.com/user-attachments/assets/64efb610-2936-4417-9504-ef5732d9fe13" />
<img width="1511" height="899" alt="image" src="https://github.com/user-attachments/assets/f4c11420-a638-4bdc-a53c-afc819b8a5b0" />
<img width="1511" height="899" alt="image" src="https://github.com/user-attachments/assets/a0314071-6e60-4ce7-811c-8baf70ec911c" />
 |




## Related PRs

<!-- optional -->
