### PR TITLE
feat(linkedin): implement posting (with image) feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 
 # OS junk
 .DS_Store
+
+# env files
+.env

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,67 @@
+# LinkedIn OAuth Setup Guide
+
+## 🔐 **OAuth 2.0 Setup Steps**
+
+### **1. Create LinkedIn App**
+
+1. Go to [LinkedIn Developer Portal](https://www.linkedin.com/developers/)
+2. Click "Create App"
+3. Fill in app details:
+   - **App name**: Your App Name
+   - **LinkedIn Page**: Select your company page
+   - **Privacy Policy URL**: Your privacy policy
+   - **App logo**: Upload a logo
+4. Click "Create app"
+
+### **2. Configure OAuth Settings**
+
+1. In your app dashboard, go to "Auth" tab
+2. Add redirect URL: `http://localhost:3000/linkedin/callback`
+3. Request these scopes:
+   - `w_member_social` (for posting)
+4. Note down your **Client ID** and **Client Secret**
+
+### **3. Set Environment Variables**
+
+Create a `.env` file in the project root:
+
+```bash
+LINKEDIN_ACCESS_TOKEN=your_access_token
+AUTHOR_PERSON_URI=your_profile_id
+```
+
+### **4. Test the Flow**
+
+1. Start backend: `uvicorn backend.main:app --reload --port 8000`
+2. Start frontend: `npm run dev`
+3. Go to `http://localhost:3000/linkedin`
+4. Enter text
+5. Click post
+
+## 🚀 **Testing Commands**
+
+```bash
+# Backend
+cd backend
+source venv/bin/activate
+uvicorn main:app --reload --port 8000
+
+# Frontend
+cd frontend
+npm run dev
+```
+
+## 🔧 **Troubleshooting**
+
+- **CORS errors**: Make sure backend is running on port 8000
+- **OAuth errors**: Check your redirect URI matches exactly
+- **API errors**: Verify your LinkedIn app has the right permissions
+- **Token errors**: Check that your client ID/secret are correct
+
+## 📝 **Production Notes**
+
+- Use environment variables for secrets
+- Store tokens in a database (not in-memory)
+- Add proper error handling
+- Implement token refresh logic
+- Add user session management

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+LINKEDIN_ACCESS_TOKEN=abcd1234abcd1234qwertyuiopasdfghjklzzxcvbnm
+AUTHOR_PERSON_URI=abc-aBcDeF

--- a/backend/linkedin_service.py
+++ b/backend/linkedin_service.py
@@ -1,0 +1,122 @@
+import httpx
+import os
+from fastapi import UploadFile
+from typing import Optional, Tuple
+
+class LinkedInService:
+    def __init__(self):
+        self.access_token = os.getenv('LINKEDIN_ACCESS_TOKEN')
+        self.user_id = os.getenv('LINKEDIN_USER_ID', 'qzt-jTlMWM')
+        
+    async def upload_image_to_linkedin(self, image_file: UploadFile) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Handle the 3-step LinkedIn image upload process
+        Returns: (asset_urn, error_message)
+        """
+        try:
+            # Step 1: Register upload request
+            register_url = "https://api.linkedin.com/v2/assets?action=registerUpload"
+            register_payload = {
+                "registerUploadRequest": {
+                    "recipes": ["urn:li:digitalmediaRecipe:feedshare-image"],
+                    "owner": f"urn:li:person:{self.user_id}",
+                    "serviceRelationships": [
+                        {
+                            "relationshipType": "OWNER",
+                            "identifier": "urn:li:userGeneratedContent"
+                        }
+                    ]
+                }
+            }
+            
+            headers = {
+                "Authorization": f"Bearer {self.access_token}",
+                "Content-Type": "application/json",
+                "X-Restli-Protocol-Version": "2.0.0"
+            }
+            
+            async with httpx.AsyncClient() as client:
+                # Step 1: Register upload
+                register_response = await client.post(register_url, json=register_payload, headers=headers)
+                
+                if register_response.status_code != 200:
+                    return None, f"Register upload failed: {register_response.text}"
+                
+                register_data = register_response.json()
+                upload_url = register_data["value"]["uploadMechanism"]["com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest"]["uploadUrl"]
+                asset_urn = register_data["value"]["asset"]
+                
+                # Step 2: Upload image
+                image_content = await image_file.read()
+                upload_headers = {
+                    "media-type-family": "STILLIMAGE"
+                }
+                
+                upload_response = await client.put(upload_url, content=image_content, headers=upload_headers)
+                
+                if upload_response.status_code not in [200, 201]:
+                    return None, f"Image upload failed: {upload_response.text}"
+                
+                return asset_urn, None
+                
+        except Exception as e:
+            return None, f"Image upload error: {str(e)}"
+    
+    async def post_to_linkedin(self, text: str, image_file: Optional[UploadFile] = None) -> dict:
+        """
+        Post text and optional image to LinkedIn
+        """
+        try:
+            linkedin_url = "https://api.linkedin.com/v2/ugcPosts"
+            
+            # Base payload
+            payload = {
+                "author": f"urn:li:person:{self.user_id}",
+                "lifecycleState": "PUBLISHED",
+                "specificContent": {
+                    "com.linkedin.ugc.ShareContent": {
+                        "shareCommentary": {
+                            "text": text
+                        },
+                        "shareMediaCategory": "NONE"
+                    }
+                },
+                "visibility": {
+                    "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+                }
+            }
+            
+            # Handle image upload if provided
+            if image_file:
+                asset_urn, error = await self.upload_image_to_linkedin(image_file)
+                if error:
+                    return {"error": error}
+                
+                # Update payload for image post
+                payload["specificContent"]["com.linkedin.ugc.ShareContent"]["shareMediaCategory"] = "IMAGE"
+                payload["specificContent"]["com.linkedin.ugc.ShareContent"]["media"] = [
+                    {
+                        "status": "READY",
+                        "description": {"text": "Uploaded image"},
+                        "media": asset_urn,
+                        "title": {"text": "Image post"}
+                    }
+                ]
+            
+            headers = {
+                "Authorization": f"Bearer {self.access_token}",
+                "Content-Type": "application/json",
+                "X-Restli-Protocol-Version": "2.0.0"
+            }
+            
+            # Step 3: Post to LinkedIn
+            async with httpx.AsyncClient() as client:
+                response = await client.post(linkedin_url, json=payload, headers=headers)
+                
+                if response.status_code == 201:
+                    return {"id": response.json().get("id"), "message": "Post created successfully"}
+                else:
+                    return {"error": f"LinkedIn API error: {response.status_code} - {response.text}"}
+                    
+        except Exception as e:
+            return {"error": f"Error posting to LinkedIn: {str(e)}"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, File, UploadFile, Form
 from fastapi.middleware.cors import CORSMiddleware
 import httpx
 import os
@@ -34,28 +34,24 @@ def say_hello():
 class PostRequest(BaseModel):
     text: str
 
-# Simple LinkedIn post endpoint
-@app.post("/api/linkedin/post")
-async def post_to_linkedin(request: PostRequest):
+# LinkedIn image upload helper
+async def upload_image_to_linkedin(image_file: UploadFile):
     """
-    Post a custom message to LinkedIn
+    Handle the 3-step LinkedIn image upload process
     """
     try:
-        linkedin_url = "https://api.linkedin.com/v2/ugcPosts"
-        
-        payload = {
-            "author": f"urn:li:person:{os.getenv('LINKEDIN_USER_ID')}",
-            "lifecycleState": "PUBLISHED",
-            "specificContent": {
-                "com.linkedin.ugc.ShareContent": {
-                    "shareCommentary": {
-                        "text": request.text
-                    },
-                    "shareMediaCategory": "NONE"
-                }
-            },
-            "visibility": {
-                "com.linkedin.ugc.MemberNetworkVisibility": "CONNECTIONS"
+        # Step 1: Register upload request
+        register_url = "https://api.linkedin.com/v2/assets?action=registerUpload"
+        register_payload = {
+            "registerUploadRequest": {
+                "recipes": ["urn:li:digitalmediaRecipe:feedshare-image"],
+                "owner": f"urn:li:person:{os.getenv('LINKEDIN_USER_ID')}",
+                "serviceRelationships": [
+                    {
+                        "relationshipType": "OWNER",
+                        "identifier": "urn:li:userGeneratedContent"
+                    }
+                ]
             }
         }
         
@@ -65,14 +61,94 @@ async def post_to_linkedin(request: PostRequest):
             "X-Restli-Protocol-Version": "2.0.0"
         }
         
-        # Make request to LinkedIn API
+        async with httpx.AsyncClient() as client:
+            # Step 1: Register upload
+            register_response = await client.post(register_url, json=register_payload, headers=headers)
+            
+            if register_response.status_code != 200:
+                return None, f"Register upload failed: {register_response.text}"
+            
+            register_data = register_response.json()
+            upload_url = register_data["value"]["uploadMechanism"]["com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest"]["uploadUrl"]
+            asset_urn = register_data["value"]["asset"]
+            
+            # Step 2: Upload image
+            image_content = await image_file.read()
+            upload_headers = {
+                "media-type-family": "STILLIMAGE"
+            }
+            
+            upload_response = await client.put(upload_url, content=image_content, headers=upload_headers)
+            
+            if upload_response.status_code not in [200, 201]:
+                return None, f"Image upload failed: {upload_response.text}"
+            
+            return asset_urn, None
+            
+    except Exception as e:
+        return None, f"Image upload error: {str(e)}"
+
+# LinkedIn post endpoint with image support
+@app.post("/api/linkedin/post")
+async def post_to_linkedin(
+    text: str = Form(...),
+    image: UploadFile = File(None)
+):
+    """
+    Post text and optional image to LinkedIn
+    """
+    try:
+        linkedin_url = "https://api.linkedin.com/v2/ugcPosts"
+        
+        # Base payload
+        payload = {
+            "author": f"urn:li:person:{os.getenv('LINKEDIN_USER_ID')}",
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    "shareCommentary": {
+                        "text": text
+                    },
+                    "shareMediaCategory": "NONE"
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+            }
+        }
+        
+        # Handle image upload if provided
+        if image:
+            asset_urn, error = await upload_image_to_linkedin(image)
+            if error:
+                return {"error": error}
+            
+            # Update payload for image post
+            payload["specificContent"]["com.linkedin.ugc.ShareContent"]["shareMediaCategory"] = "IMAGE"
+            payload["specificContent"]["com.linkedin.ugc.ShareContent"]["media"] = [
+                {
+                    "status": "READY",
+                    "description": {"text": "Uploaded image"},
+                    "media": asset_urn,
+                    "title": {"text": "Image post"}
+                }
+            ]
+        
+        headers = {
+            "Authorization": f"Bearer {os.getenv('LINKEDIN_ACCESS_TOKEN')}",
+            "Content-Type": "application/json",
+            "X-Restli-Protocol-Version": "2.0.0"
+        }
+        
+        # Step 3: Post to LinkedIn
         async with httpx.AsyncClient() as client:
             response = await client.post(linkedin_url, json=payload, headers=headers)
             
             if response.status_code == 201:
-                return {"id": response.json().get("id"), "message": "Demo post created successfully"}
+                return {"id": response.json().get("id"), "message": "Post created successfully"}
             else:
                 return {"error": f"LinkedIn API error: {response.status_code} - {response.text}"}
                 
     except Exception as e:
         return {"error": f"Error posting to LinkedIn: {str(e)}"}
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI, File, UploadFile, Form
 from fastapi.middleware.cors import CORSMiddleware
-import httpx
 import os
 from dotenv import load_dotenv
 from pydantic import BaseModel
+from linkedin_service import LinkedInService
 
 # Load environment variables
 load_dotenv()
@@ -34,60 +34,6 @@ def say_hello():
 class PostRequest(BaseModel):
     text: str
 
-# LinkedIn image upload helper
-async def upload_image_to_linkedin(image_file: UploadFile):
-    """
-    Handle the 3-step LinkedIn image upload process
-    """
-    try:
-        # Step 1: Register upload request
-        register_url = "https://api.linkedin.com/v2/assets?action=registerUpload"
-        register_payload = {
-            "registerUploadRequest": {
-                "recipes": ["urn:li:digitalmediaRecipe:feedshare-image"],
-                "owner": f"urn:li:person:{os.getenv('LINKEDIN_USER_ID')}",
-                "serviceRelationships": [
-                    {
-                        "relationshipType": "OWNER",
-                        "identifier": "urn:li:userGeneratedContent"
-                    }
-                ]
-            }
-        }
-        
-        headers = {
-            "Authorization": f"Bearer {os.getenv('LINKEDIN_ACCESS_TOKEN')}",
-            "Content-Type": "application/json",
-            "X-Restli-Protocol-Version": "2.0.0"
-        }
-        
-        async with httpx.AsyncClient() as client:
-            # Step 1: Register upload
-            register_response = await client.post(register_url, json=register_payload, headers=headers)
-            
-            if register_response.status_code != 200:
-                return None, f"Register upload failed: {register_response.text}"
-            
-            register_data = register_response.json()
-            upload_url = register_data["value"]["uploadMechanism"]["com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest"]["uploadUrl"]
-            asset_urn = register_data["value"]["asset"]
-            
-            # Step 2: Upload image
-            image_content = await image_file.read()
-            upload_headers = {
-                "media-type-family": "STILLIMAGE"
-            }
-            
-            upload_response = await client.put(upload_url, content=image_content, headers=upload_headers)
-            
-            if upload_response.status_code not in [200, 201]:
-                return None, f"Image upload failed: {upload_response.text}"
-            
-            return asset_urn, None
-            
-    except Exception as e:
-        return None, f"Image upload error: {str(e)}"
-
 # LinkedIn post endpoint with image support
 @app.post("/api/linkedin/post")
 async def post_to_linkedin(
@@ -97,58 +43,6 @@ async def post_to_linkedin(
     """
     Post text and optional image to LinkedIn
     """
-    try:
-        linkedin_url = "https://api.linkedin.com/v2/ugcPosts"
-        
-        # Base payload
-        payload = {
-            "author": f"urn:li:person:{os.getenv('LINKEDIN_USER_ID')}",
-            "lifecycleState": "PUBLISHED",
-            "specificContent": {
-                "com.linkedin.ugc.ShareContent": {
-                    "shareCommentary": {
-                        "text": text
-                    },
-                    "shareMediaCategory": "NONE"
-                }
-            },
-            "visibility": {
-                "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
-            }
-        }
-        
-        # Handle image upload if provided
-        if image:
-            asset_urn, error = await upload_image_to_linkedin(image)
-            if error:
-                return {"error": error}
-            
-            # Update payload for image post
-            payload["specificContent"]["com.linkedin.ugc.ShareContent"]["shareMediaCategory"] = "IMAGE"
-            payload["specificContent"]["com.linkedin.ugc.ShareContent"]["media"] = [
-                {
-                    "status": "READY",
-                    "description": {"text": "Uploaded image"},
-                    "media": asset_urn,
-                    "title": {"text": "Image post"}
-                }
-            ]
-        
-        headers = {
-            "Authorization": f"Bearer {os.getenv('LINKEDIN_ACCESS_TOKEN')}",
-            "Content-Type": "application/json",
-            "X-Restli-Protocol-Version": "2.0.0"
-        }
-        
-        # Step 3: Post to LinkedIn
-        async with httpx.AsyncClient() as client:
-            response = await client.post(linkedin_url, json=payload, headers=headers)
-            
-            if response.status_code == 201:
-                return {"id": response.json().get("id"), "message": "Post created successfully"}
-            else:
-                return {"error": f"LinkedIn API error: {response.status_code} - {response.text}"}
-                
-    except Exception as e:
-        return {"error": f"Error posting to LinkedIn: {str(e)}"}
+    linkedin_service = LinkedInService()
+    return await linkedin_service.post_to_linkedin(text, image)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,12 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import httpx
+import os
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+# Load environment variables
+load_dotenv()
 
 # Create FastAPI app
 app = FastAPI()
@@ -22,3 +29,50 @@ def read_root():
 @app.get("/api/hello")
 def say_hello():
     return {"message": "Hello from /api/hello"}
+
+# Pydantic model for request body
+class PostRequest(BaseModel):
+    text: str
+
+# Simple LinkedIn post endpoint
+@app.post("/api/linkedin/post")
+async def post_to_linkedin(request: PostRequest):
+    """
+    Post a custom message to LinkedIn
+    """
+    try:
+        linkedin_url = "https://api.linkedin.com/v2/ugcPosts"
+        
+        payload = {
+            "author": f"urn:li:person:{os.getenv('LINKEDIN_USER_ID')}",
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    "shareCommentary": {
+                        "text": request.text
+                    },
+                    "shareMediaCategory": "NONE"
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": "CONNECTIONS"
+            }
+        }
+        
+        headers = {
+            "Authorization": f"Bearer {os.getenv('LINKEDIN_ACCESS_TOKEN')}",
+            "Content-Type": "application/json",
+            "X-Restli-Protocol-Version": "2.0.0"
+        }
+        
+        # Make request to LinkedIn API
+        async with httpx.AsyncClient() as client:
+            response = await client.post(linkedin_url, json=payload, headers=headers)
+            
+            if response.status_code == 201:
+                return {"id": response.json().get("id"), "message": "Demo post created successfully"}
+            else:
+                return {"error": f"LinkedIn API error: {response.status_code} - {response.text}"}
+                
+    except Exception as e:
+        return {"error": f"Error posting to LinkedIn: {str(e)}"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
 # Core FastAPI dependencies
 fastapi==0.115.13
 uvicorn==0.34.3
+httpx==0.28.1
+python-dotenv==1.1.1

--- a/frontend/src/app/linkedin/page.tsx
+++ b/frontend/src/app/linkedin/page.tsx
@@ -7,6 +7,14 @@ export default function LinkedInPost() {
   const [result, setResult] = useState('')
   const [postText, setPostText] = useState('')
   const [linkedinUrl, setLinkedinUrl] = useState('')
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      setSelectedFile(file)
+    }
+  }
 
   const handlePost = async () => {
     setIsPosting(true)
@@ -14,14 +22,15 @@ export default function LinkedInPost() {
     setLinkedinUrl('')
 
     try {
+      const formData = new FormData()
+      formData.append('text', postText)
+      if (selectedFile) {
+        formData.append('image', selectedFile)
+      }
+
       const response = await fetch('http://localhost:8000/api/linkedin/post', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          text: postText
-        })
+        body: formData
       })
       const data = await response.json()
 
@@ -59,6 +68,24 @@ export default function LinkedInPost() {
               className="w-full text-black h-32 p-4 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent resize-none"
             />
             <div className="text-sm text-gray-500 mt-2">{postText.length} characters</div>
+          </div>
+
+          <div className="mb-6">
+            <label htmlFor="imageUpload" className="block text-sm font-medium text-gray-700 mb-2">
+              Upload an image (optional)
+            </label>
+            <input
+              id="imageUpload"
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+              className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+            />
+            {selectedFile && (
+              <div className="mt-2 text-sm text-gray-600">
+                Selected: {selectedFile.name} ({(selectedFile.size / 1024 / 1024).toFixed(2)} MB)
+              </div>
+            )}
           </div>
 
           <div className="text-center">

--- a/frontend/src/app/linkedin/page.tsx
+++ b/frontend/src/app/linkedin/page.tsx
@@ -1,14 +1,17 @@
 'use client'
 import { useState } from 'react'
+import { LINKEDIN_VIEW_POST_URL } from './utils/constants'
 
 export default function LinkedInPost() {
   const [isPosting, setIsPosting] = useState(false)
   const [result, setResult] = useState('')
   const [postText, setPostText] = useState('')
+  const [linkedinUrl, setLinkedinUrl] = useState('')
 
   const handlePost = async () => {
     setIsPosting(true)
     setResult('')
+    setLinkedinUrl('')
 
     try {
       const response = await fetch('http://localhost:8000/api/linkedin/post', {
@@ -23,7 +26,8 @@ export default function LinkedInPost() {
       const data = await response.json()
 
       if (response.ok) {
-        setResult(`Success! Post ID: ${data.id}`)
+        setResult('Success!')
+        setLinkedinUrl(`https://www.linkedin.com/feed/update/${data.id}`)
       } else {
         setResult(`Error: ${data.error || 'Failed to post'}`)
       }
@@ -52,7 +56,7 @@ export default function LinkedInPost() {
               value={postText}
               onChange={(e) => setPostText(e.target.value)}
               placeholder="Enter your LinkedIn post content here..."
-              className="w-full h-32 p-4 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent resize-none"
+              className="w-full text-black h-32 p-4 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent resize-none"
             />
             <div className="text-sm text-gray-500 mt-2">{postText.length} characters</div>
           </div>
@@ -70,7 +74,17 @@ export default function LinkedInPost() {
 
         {result && (
           <div className="mt-6 p-4 rounded-lg bg-gray-100 border-l-4 border-brand-blue">
-            <p className="text-gray-800">{result}</p>
+            <p className="text-gray-800 mb-2">{result}</p>
+            {linkedinUrl && (
+              <a
+                href={linkedinUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center text-brand-blue hover:text-blue-600 underline font-medium"
+              >
+                View your post on LinkedIn →
+              </a>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/app/linkedin/page.tsx
+++ b/frontend/src/app/linkedin/page.tsx
@@ -1,0 +1,79 @@
+'use client'
+import { useState } from 'react'
+
+export default function LinkedInPost() {
+  const [isPosting, setIsPosting] = useState(false)
+  const [result, setResult] = useState('')
+  const [postText, setPostText] = useState('')
+
+  const handlePost = async () => {
+    setIsPosting(true)
+    setResult('')
+
+    try {
+      const response = await fetch('http://localhost:8000/api/linkedin/post', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          text: postText
+        })
+      })
+      const data = await response.json()
+
+      if (response.ok) {
+        setResult(`Success! Post ID: ${data.id}`)
+      } else {
+        setResult(`Error: ${data.error || 'Failed to post'}`)
+      }
+    } catch (error) {
+      setResult(`Network error: ${error}`)
+    } finally {
+      setIsPosting(false)
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-brand-light p-8">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-brand-dark text-white p-6 rounded-lg shadow-lg mb-6">
+          <h1 className="text-3xl font-bold mb-2 text-brand-blue">LinkedIn Demo Post</h1>
+          <p className="text-brand-light">Click the button to post a demo message to LinkedIn</p>
+        </div>
+
+        <div className="bg-white rounded-lg shadow-lg p-6">
+          <div className="mb-6">
+            <label htmlFor="postText" className="block text-sm font-medium text-gray-700 mb-2">
+              What do you want to post?
+            </label>
+            <textarea
+              id="postText"
+              value={postText}
+              onChange={(e) => setPostText(e.target.value)}
+              placeholder="Enter your LinkedIn post content here..."
+              className="w-full h-32 p-4 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent resize-none"
+            />
+            <div className="text-sm text-gray-500 mt-2">{postText.length} characters</div>
+          </div>
+
+          <div className="text-center">
+            <button
+              onClick={handlePost}
+              disabled={isPosting || !postText.trim()}
+              className="bg-brand-blue text-white px-8 py-4 rounded-lg font-medium hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-lg"
+            >
+              {isPosting ? 'Posting...' : 'Post to LinkedIn'}
+            </button>
+          </div>
+        </div>
+
+        {result && (
+          <div className="mt-6 p-4 rounded-lg bg-gray-100 border-l-4 border-brand-blue">
+            <p className="text-gray-800">{result}</p>
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/linkedin/utils/constants.ts
+++ b/frontend/src/app/linkedin/utils/constants.ts
@@ -1,0 +1,1 @@
+export const LINKEDIN_VIEW_POST_URL = 'https://www.linkedin.com/feed/update/'


### PR DESCRIPTION
## Purpose

The goal of this PR is to enabling posting on Linkedin using credentials (rather than OAuth 2.0), which will be implemented later

## Steps to check/test this change
- checkout this branch
- follow the setup.md, read the linkedin docs, consult a youtube video, or ping @SimonNRisk for instructions on how to setup your linkedin api with keys

## Checklist

- [x] Tested in development
- [ ] Test coverage added

## Proof

<video src="https://github.com/user-attachments/assets/36ab37da-7668-4c35-a548-abfc09c328e6" />

