### PR TITLE
fix: add email validator to requirements.clean.txt

### DIFF
--- a/backend/requirements.clean.txt
+++ b/backend/requirements.clean.txt
@@ -2,6 +2,7 @@ absl-py==2.3.1
 # anaconda-client==1.12.0
 # anaconda-navigator==2.4.2
 annotated-types==0.7.0
+email-validator==2.3.0
 anyio==4.9.0
 appdirs==1.4.4
 asgiref==3.8.1


### PR DESCRIPTION
## Purpose
We were missing this in our requirements.clean.txt which prevents us from locally running our backend