### PR TITLE
fix: only expose sidebar on specific routes

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
-import { Sidebar } from '@/components/Sidebar';
+import { ConditionalSidebar } from '@/components/ConditionalSidebar';
+import { ConditionalLayout } from '@/components/ConditionalLayout';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -26,8 +27,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Sidebar />
-        <div className="ml-20">{children}</div>
+        <ConditionalSidebar />
+        <ConditionalLayout>{children}</ConditionalLayout>
       </body>
     </html>
   );

--- a/frontend/src/components/ConditionalLayout.tsx
+++ b/frontend/src/components/ConditionalLayout.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { shouldShowSidebar } from '@/lib/routes';
+
+export function ConditionalLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  return <div className={shouldShowSidebar(pathname) ? 'ml-20' : ''}>{children}</div>;
+}

--- a/frontend/src/components/ConditionalSidebar.tsx
+++ b/frontend/src/components/ConditionalSidebar.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { Sidebar } from './Sidebar';
+import { shouldShowSidebar } from '@/lib/routes';
+
+export function ConditionalSidebar() {
+  const pathname = usePathname();
+
+  if (!shouldShowSidebar(pathname)) {
+    return null;
+  }
+
+  return <Sidebar />;
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -1,0 +1,20 @@
+// Routes that should NOT show the sidebar (unauthenticated routes)
+export const EXCLUDED_SIDEBAR_ROUTES = [
+  '/login',
+  '/signup',
+  '/onboarding',
+  '/auth/callback',
+  '/linkedin-connect',
+  '/linkedin-connect/callback',
+];
+
+/**
+ * Check if a given pathname should show the sidebar
+ */
+export function shouldShowSidebar(pathname: string | null): boolean {
+  if (!pathname) return false;
+
+  return !EXCLUDED_SIDEBAR_ROUTES.some(
+    route => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}


### PR DESCRIPTION
## Purpose

We only want the sidebar on some routes: onboarded routes where the user has a verified account

## Checklist

- [x] Tested in development